### PR TITLE
Added Entity-related Crop Trample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,77 @@
+# Created by https://www.gitignore.io/api/intellij
+
+### Intellij ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+/target/
+/out/
+/libs/
+/.idea/
+/*.iml
+*.iml
+src/**/META-INF
+dependency-reduced-pom.xml
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+### Intellij Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+
+# End of https://www.gitignore.io/api/intellij

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <version>1.14.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/michaelinfernus/stoptramplingmycrops/StopTramplingMyCrops.java
+++ b/src/main/java/com/michaelinfernus/stoptramplingmycrops/StopTramplingMyCrops.java
@@ -1,6 +1,7 @@
 package com.michaelinfernus.stoptramplingmycrops;
 
 import com.michaelinfernus.stoptramplingmycrops.commands.TrampleCommand;
+import com.michaelinfernus.stoptramplingmycrops.listeners.EntityInteractListeners;
 import com.michaelinfernus.stoptramplingmycrops.listeners.PlayerInteractListeners;
 import org.bukkit.ChatColor;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -28,6 +29,7 @@ public final class StopTramplingMyCrops extends JavaPlugin {
 
     private void enableListeners() {
         this.getServer().getPluginManager().registerEvents(new PlayerInteractListeners(this), this);
+        this.getServer().getPluginManager().registerEvents(new EntityInteractListeners(this), this);
     }
 
     private void loadCommands() {

--- a/src/main/java/com/michaelinfernus/stoptramplingmycrops/listeners/EntityInteractListeners.java
+++ b/src/main/java/com/michaelinfernus/stoptramplingmycrops/listeners/EntityInteractListeners.java
@@ -1,0 +1,35 @@
+package com.michaelinfernus.stoptramplingmycrops.listeners;
+
+import com.michaelinfernus.stoptramplingmycrops.StopTramplingMyCrops;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityInteractEvent;
+
+public class EntityInteractListeners implements Listener {
+
+    private StopTramplingMyCrops plugin;
+
+    public EntityInteractListeners(StopTramplingMyCrops pl) {
+        this.plugin = pl;
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onPlayerInteractEvent(EntityInteractEvent event) {
+        if(plugin.getConfig().getBoolean("stop-trampling-enabled") && plugin.getConfig().getBoolean("stop-entity-trample")) {
+            Block block = event.getBlock();
+            World world = block.getWorld();
+            if (plugin.getWorldsList().contains("all") || plugin.getWorldsList().contains(world.getName())) {
+                if(block.getType() == Material.FARMLAND) {
+                    event.setCancelled(true); //cancel the trampling
+                    block.setBlockData(block.getBlockData(), true);
+                    block.setType(block.getType(), true);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,6 @@
 prefix: '&7[&eStopTramplingMyCrops&7] &f'
 stop-trampling-enabled: true
+stop-entity-trample: true
 trample-less-worlds:
   - worldName
  #- all


### PR DESCRIPTION
- Updated POM to reflect the most recent version (1.14.4).
- Entities can now no longer trample crops if "stop-entity-trample" is enabled in the config (respects "stop-trampling-enabled").